### PR TITLE
Added config.auth to options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ module.exports.register = function (server, options, cb) {
         healthCheck: function (_server, callback) {
 
             callback();
-        }
+        },
+        auth: false
     };
 
     options = Hoek.applyToDefaults(defaults, options);
@@ -46,7 +47,8 @@ module.exports.register = function (server, options, cb) {
                         stripUnknown: false
                     })
                 }
-            }
+            },
+            auth: options.auth
         }
     });
 


### PR DESCRIPTION
When using Authorization in Hapi, the health check path is
not accessible without authenticating first. To avoid this
you could set config.auth to false.

Example: https://github.com/dwyl/hapi-auth-jwt2